### PR TITLE
アイディア作成画面でタグ選択登録実装

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -20,6 +20,7 @@ class IdeasController < ApplicationController
   # GET /ideas/new
   def new
     @idea = current_user.idea.build if user_signed_in?
+    @tags = Idea.tag_counts_on(:tags)
   end
 
   # GET /ideas/1/edit
@@ -47,10 +48,6 @@ class IdeasController < ApplicationController
   # PATCH/PUT /ideas/1
   # PATCH/PUT /ideas/1.json
   def update
-    params[:taglist].each do | di1,di2 |
-      logger.debug('d1 :' + di1)
-      logger.debug('d2 :' + di2)
-    end
     respond_to do |format|
       if @idea.update(idea_params)
         format.html { redirect_to @idea, notice: 'Idea was successfully updated.' }
@@ -80,6 +77,6 @@ class IdeasController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def idea_params
-      params.require(:idea).permit(:user_id, :subject, :body, :tag_list)
+      params.require(:idea).permit(:user_id, :subject, :body, tag_list: [])
     end
 end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -1,4 +1,4 @@
-class Idea < ApplicationRecord
-    acts_as_taggable
+class Idea < ActiveRecord::Base
+    acts_as_taggable_on :tags
     belongs_to :user
 end

--- a/app/views/ideas/_form.html.slim
+++ b/app/views/ideas/_form.html.slim
@@ -13,12 +13,13 @@
     = form.text_field :subject
   .field
     = form.label :body
-    = form.text_field :body
-  .field.form-group.form-group-lg
-    = form.label :tag_list, class: "sr-only control-label"
-    = form.text_field :tag_list, value: @idea.tag_list.join(','), class: "form-control"
-  - tag_cloud(@tags, %w(css1 css2 css3 css4)) do |tag, css_class|
-    = check_box "taglist", tag.id
-    = tag.name
+    = form.text_area :body
+
+  ul.field.option_check
+    - @tags.each do |tag|
+      li
+        label for="idea_tag_list_#{tag.id.to_s}"
+          = form.check_box :tag_list, {multiple: true, checked: @idea.tag_list.include?(tag.name.to_s)}, tag.name.to_s, ''
+          span.checkbox =  tag.name
   .actions
     = form.submit

--- a/app/views/ideas/index.html.slim
+++ b/app/views/ideas/index.html.slim
@@ -17,6 +17,8 @@ table
       th
         | Body
       th
+        | tags
+      th
         | Is delete
       th[colspan="3"]
   tbody
@@ -28,6 +30,10 @@ table
           = idea.subject
         td
           = idea.body
+        td
+          - idea.tag_list.each do |tag|
+              span.label.label-primary
+                = tag
         td
           = link_to 'Show', idea
         td

--- a/db/migrate/20191123040129_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20191123040129_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -8,7 +8,10 @@ AddMissingUniqueIndices.class_eval do
   def self.up
     add_index ActsAsTaggableOn.tags_table, :name, unique: true
 
-    #remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+      remove_foreign_key :taggings, :tags
+      remove_index ActsAsTaggableOn.taggings_table, :tag_id
+    end
     remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
     add_index ActsAsTaggableOn.taggings_table,
               [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],


### PR DESCRIPTION
アイディア登録画面でタグをチェックボックスでの複数選択、登録可能にする。